### PR TITLE
Correct documentation of Keyboard.presses

### DIFF
--- a/src/Keyboard.elm
+++ b/src/Keyboard.elm
@@ -42,7 +42,7 @@ keyCode =
 -- MOUSE EVENTS
 
 
-{-| Subscribe to all key presses.
+{-| Subscribe to all presses of keys that normally produce a character value.
 -}
 presses : (KeyCode -> msg) -> Sub msg
 presses tagger =


### PR DESCRIPTION
The current documentation is that one subscribes to presses of all keys.

But that is not true. The specification https://w3c.github.io/uievents/#keypress says:

> If supported by a user agent, this event MUST be dispatched when a key is pressed down, if and only if that key normally produces a character value.

So "all key presses" is clearly wrong. Some browsers (Chrome) do what the specification says, some browsers (Firefox) do something else. Since due to that misbehavior of some browsers, the Elm documentation cannot say something that is true for all browsers, it should instead say the thing that agrees with the specfication (and is true for some browsers, namely those that honor the specification).
