### PR TITLE
Use KeyboardEvent.which instead of KeyboardEvent.keyCode

### DIFF
--- a/src/Keyboard.elm
+++ b/src/Keyboard.elm
@@ -33,9 +33,9 @@ type alias KeyCode =
   Int
 
 
-keyCode : Json.Decoder KeyCode
-keyCode =
-  Json.field "keyCode" Json.int
+which : Json.Decoder KeyCode
+which =
+  Json.field "which" Json.int
 
 
 
@@ -154,7 +154,7 @@ onEffects router newSubs oldState =
 
     rightStep category taggers task =
       task
-        |> Task.andThen (\state -> Process.spawn (Dom.onDocument category keyCode (Platform.sendToSelf router << Msg category))
+        |> Task.andThen (\state -> Process.spawn (Dom.onDocument category which (Platform.sendToSelf router << Msg category))
         |> Task.andThen (\pid -> Task.succeed (Dict.insert category (Watcher taggers pid) state)))
   in
     Dict.merge


### PR DESCRIPTION
## The problem

Currently, `Keyboard.presses` does not work in all browsers. It is supposed to give key codes for character key presses, see https://github.com/elm-lang/keyboard/pull/5#issue-169623909, but it doesn't for example in Firefox.
## The cause

Currently, the `keyCode` property of keyboard events is queried in the native implementation of this package. But there is no guarantee from the specification, and it also is not the case in practice, that that property is always set. From [MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode) (see section "Notes" there):

> In a `keypress` event, the Unicode value of the key pressed is stored in either the `keyCode` or `charCode` property, never both.

Only querying `keyCode` is consequently doomed to fail in general, and the behavior many users have observed in Firefox and complained about is the upshot of this.
## The solution

Don't query `keyCode`, query `which`, as this pull request does. This is a solution, because, also from the MDN section mentioned above:

> To get the code of the key regardless of whether it was stored in `keyCode` or `charCode`, query the `which` property.
## Are there unintended consequences for other functionality?

No, because `which` will also work for `Keyboard.ups` and `Keyboard.downs`. Again from MDN:

> `charCode` is never set in the `keydown` and `keyup` events. In these cases, `keyCode` is set instead.

... and the above MDN statement about `which` containing whatever is stored in `keyCode` or `charCode` does still apply.
## Is this all just the case in theory and according to the specification, or does it also hold in practice?

It also holds in practice. Browsers behave in such a way that querying `which` instead of `keyCode` would work (to the extent it was possible for me to test). See past research in https://github.com/elm-lang/core/pull/463#issue-122207532.
## But isn't `which` marked as deprecated by MDN?

Yes, it is. But so is `keyCode` that is currently used. Using `which` is not more deprecated than using `keyCode`. Actually in a sense less so, see the MDN quotes above.
## Is this change backwards compatible, guaranteed not to break existing programs?

Yes. According to everything I have found out, whichever combination of use of `elm-lang/keyboard` and specific browser works currently would continue to work in exactly the same way. In addition, new combinations will work (e.g., in Firefox being able to register character key presses). So it is a strict improvement, no downside.
## Is the problem solved really a problem that users of `elm-lang/keyboard` have?

Yes, it is. It was when this functionality lived in `elm-lang/core` and it still is after the transition to the new package. A collection of some user reports that were about exactly this problem: https://github.com/elm-lang/core/issues/326, https://github.com/elm-lang/core/issues/427, https://github.com/elm-lang/core/issues/462, https://github.com/elm-lang/elm-compiler/issues/1069, https://github.com/elm-lang/elm-platform/issues/123, https://github.com/elm-lang/elm-lang.org/issues/440, https://github.com/kbsymanz/hangman-elm/issues/1, https://github.com/elm-lang/keyboard/issues/3.
